### PR TITLE
Fix concerts folder path in GitHub Action

### DIFF
--- a/.github/workflows/update-bulletins.yml
+++ b/.github/workflows/update-bulletins.yml
@@ -43,7 +43,7 @@ jobs:
           LLM_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
         run: |
-          python generate_bulletin.py concerts/
+          python generate_bulletin.py bulletins/concerts/
       
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
## Summary
Fixes the failing GitHub Action by updating the concerts folder path.

## Problem
The GitHub Action was failing with the error:
```
Error: Folder '/home/runner/work/bulletin-board/bulletin-board/concerts' does not exist.
```

This happened because the `concerts/` folder was moved to `bulletins/concerts/`, but the workflow wasn't updated.

## Fix
Updated the path in `.github/workflows/update-bulletins.yml` from `concerts/` to `bulletins/concerts/`.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)