### PR TITLE
Fix: Trigger deploy workflow after automated bulletin updates

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
   workflow_dispatch:
+  # Trigger when update-bulletins workflow completes (since GITHUB_TOKEN commits don't trigger push events)
+  workflow_run:
+    workflows: ["Update Bulletins"]
+    types:
+      - completed
+    branches:
+      - main
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -20,6 +27,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Only run if triggered by push/dispatch OR if the triggering workflow_run succeeded
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The most recent automated commit ("Update bulletins [automated]") did not trigger a GitHub Pages build. This is because commits made with the default `GITHUB_TOKEN` don't trigger other workflow events like `push` - this is a GitHub security measure to prevent infinite loops.

## Solution

Added a `workflow_run` trigger to the `deploy-site.yml` workflow, so it will automatically run when the `Update Bulletins` workflow completes. This ensures the site gets deployed after automated bulletin updates.

### Changes:
- Added `workflow_run` trigger that fires when "Update Bulletins" workflow completes on main branch
- Added a condition to only run the build if the triggering workflow succeeded (not on failure)

The existing `push` and `workflow_dispatch` triggers remain in place for manual pushes and manual triggers.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)