### PR TITLE
Fix workflow to detect new untracked files

### DIFF
--- a/.github/workflows/update-bulletins.yml
+++ b/.github/workflows/update-bulletins.yml
@@ -77,8 +77,8 @@ jobs:
           # Pull latest changes to avoid conflicts from parallel jobs
           git pull --rebase
           
-          # Check if there are changes to commit
-          if git diff --quiet; then
+          # Check if there are changes to commit (including new untracked files)
+          if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit for ${{ matrix.bulletin }}"
           else
             git add -A


### PR DESCRIPTION
## Problem

The GitHub Actions workflow was reporting "No changes to commit" even when `BULLETIN.md` was clearly created/updated. This happened because `git diff --quiet` only checks for changes in **already tracked** files - it doesn't detect new untracked files.

## Solution

Changed the check from:
```bash
if git diff --quiet; then
```
to:
```bash
if [ -z "$(git status --porcelain)" ]; then
```

`git status --porcelain` detects both:
- Modified tracked files
- **New untracked files** (like a freshly created `BULLETIN.md`)

## Testing

This fix ensures that when `generate_bulletin.py` creates a new `BULLETIN.md` file, the workflow will correctly detect and commit it.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)