### PR TITLE
Fix regex pattern in table parsing

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -259,7 +259,7 @@ def convert_table_to_html(lines: list[str]) -> str:
     # Skip separator line (lines[1])
     
     # Parse body rows
-    rows = [parse_row(line) for line in lines[2:] if not re.match(r"^[\s-:|]+$", line)]
+    rows = [parse_row(line) for line in lines[2:] if not re.match(r"^[\s\-:|]+$", line)]
     
     # Build HTML table
     html = ['<div class="table-wrapper">', '<table>']


### PR DESCRIPTION
## Summary
Fixes a regex error that was causing site generation to fail.

## Problem
The regex pattern `r"^[\s-:|]+$"` on line 262 of `generate_site.py` had an unescaped `-` in the character class. In regex, when a `-` appears between characters inside `[]`, it's interpreted as a range operator (like `a-z`). Since `\s` to `:` is not a valid range, Python threw the error:
```
re.error: bad character range \s-: at position 2
```

## Solution
Escaped the dash character: `r"^[\s\-:|]+$"`

This matches the pattern used elsewhere in the same file (line 222) which correctly escapes the dash.

## Testing
After the fix, `python generate_site.py` runs successfully and generates all pages:
- index.html
- calendar.html
- camberville.html
- concerts.html
- industry-news.html
- openhands.html
- us-politics.html

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)