### PR TITLE
Fix frontmatter cost always showing $0

### DIFF
--- a/generate_bulletin.py
+++ b/generate_bulletin.py
@@ -21,6 +21,7 @@ Environment Variables:
 
 import argparse
 import os
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -132,10 +133,22 @@ The target folder is: {folder}
     
     print("-" * 50)
     print("Bulletin generation complete!")
-    print(f"Cost: ${llm.metrics.accumulated_cost:.4f}")
+    
+    actual_cost = llm.metrics.accumulated_cost
+    print(f"Cost: ${actual_cost:.4f}")
     
     bulletin_file = folder / "BULLETIN.md"
     if bulletin_file.exists():
+        # Update the cost in frontmatter with the actual cost
+        content = bulletin_file.read_text()
+        # Match cost field in frontmatter (handles various formats like 0, 0.0, $0.00, etc.)
+        updated_content = re.sub(
+            r'^(---\n(?:.*\n)*?cost:\s*)\$?[\d.]+',
+            rf'\g<1>{actual_cost:.4f}',
+            content,
+            flags=re.MULTILINE
+        )
+        bulletin_file.write_text(updated_content)
         print(f"BULLETIN.md has been updated at: {bulletin_file}")
     else:
         print("Warning: BULLETIN.md was not created.")


### PR DESCRIPTION
## Problem

The `cost` field in the BULLETIN.md frontmatter was always `$0` (or `0`, `0.0000`, etc.) regardless of actual usage.

## Root Cause

The PROMPT.md instructs the AI agent to include `cost` in the frontmatter when writing BULLETIN.md. However, the agent writes the file during the conversation, but the actual accumulated cost (`llm.metrics.accumulated_cost`) is only available after `conversation.run()` completes.

## Solution

After the conversation finishes, the script now:
1. Reads the generated BULLETIN.md file
2. Uses a regex to find and replace the placeholder cost value in the frontmatter with the actual `llm.metrics.accumulated_cost`
3. Writes the updated content back to the file

The regex handles various formats the agent might write (e.g., `0`, `0.0000`, `$0.00`).

## Changes

- Added `import re` to `generate_bulletin.py`
- Added post-processing step to update the frontmatter cost with the actual accumulated cost

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)