### PR TITLE
Add GOOGLE_API_KEY secret support for agent

### DIFF
--- a/.github/workflows/update-bulletins.yml
+++ b/.github/workflows/update-bulletins.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           LLM_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           python generate_bulletin.py bulletins/${{ matrix.bulletin }}/
       

--- a/generate_bulletin.py
+++ b/generate_bulletin.py
@@ -15,6 +15,7 @@ Example:
 Environment Variables:
     LLM_API_KEY      - API key for the LLM (required)
     TAVILY_API_KEY   - API key for Tavily web search (optional but recommended)
+    GOOGLE_API_KEY   - Google API key for agent access (optional)
     LLM_MODEL        - Model to use (default: anthropic/claude-sonnet-4-5-20250929)
     LLM_BASE_URL     - Custom base URL for the LLM API (optional)
 """
@@ -116,6 +117,16 @@ def run_bulletin_agent(folder_path: str) -> None:
         agent=agent,
         workspace=str(folder),
     )
+    
+    # Add secrets that the agent can access
+    secrets = {}
+    google_api_key = os.getenv("GOOGLE_API_KEY")
+    if google_api_key:
+        secrets["GOOGLE_API_KEY"] = google_api_key
+        logger.info("GOOGLE_API_KEY secret registered")
+    
+    if secrets:
+        conversation.update_secrets(secrets)
     
     # Use PROMPT.md as the task, not the system prompt
     task_message = META_PROMPT.format(today_date=today_date) + f"""


### PR DESCRIPTION
## Summary

This PR adds support for the `GOOGLE_API_KEY` secret, making it available to the agent using the OpenHands SDK secrets object.

## Changes

### `generate_bulletin.py`
- Added code to register `GOOGLE_API_KEY` with the OpenHands SDK using `conversation.update_secrets()`
- Updated documentation to include `GOOGLE_API_KEY` as an optional environment variable

### `.github/workflows/update-bulletins.yml`
- Added `GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}` to pass the secret from GitHub secrets to the workflow

## How It Works

1. The GitHub workflow passes `secrets.GOOGLE_API_KEY` as an environment variable
2. The Python script reads this environment variable
3. The secret is registered with the OpenHands SDK using `conversation.update_secrets()`
4. The agent can securely access `$GOOGLE_API_KEY` in its runtime environment
5. The SDK automatically masks the secret value in any command outputs to prevent accidental exposure

## Prerequisites

Make sure `GOOGLE_API_KEY` is added to your repository's GitHub secrets.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)