### PR TITLE
Change default model to Claude Opus 4

### DIFF
--- a/generate_bulletin.py
+++ b/generate_bulletin.py
@@ -16,7 +16,7 @@ Environment Variables:
     LLM_API_KEY      - API key for the LLM (required)
     TAVILY_API_KEY   - API key for Tavily web search (optional but recommended)
     GOOGLE_API_KEY   - Google API key for agent access (optional)
-    LLM_MODEL        - Model to use (default: anthropic/claude-sonnet-4-5-20250929)
+    LLM_MODEL        - Model to use (default: anthropic/claude-opus-4-20250514)
     LLM_BASE_URL     - Custom base URL for the LLM API (optional)
 """
 
@@ -86,7 +86,7 @@ def run_bulletin_agent(folder_path: str) -> None:
         print("Error: LLM_API_KEY environment variable is not set.")
         sys.exit(1)
     
-    model = os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929")
+    model = os.getenv("LLM_MODEL", "anthropic/claude-opus-4-20250514")
     base_url = os.getenv("LLM_BASE_URL")
     
     llm = LLM(


### PR DESCRIPTION
## Summary

This PR updates the default LLM model from Claude Sonnet 4.5 to Claude Opus 4.

## Changes

- Updated default model from `anthropic/claude-sonnet-4-5-20250929` to `anthropic/claude-opus-4-20250514`
- Updated documentation to reflect the new default model

## Notes

The model can still be overridden by setting the `LLM_MODEL` environment variable.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)