### PR TITLE
Fix git pull --rebase failing with unstaged changes

### DIFF
--- a/.github/workflows/update-bulletins.yml
+++ b/.github/workflows/update-bulletins.yml
@@ -76,13 +76,21 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # Pull latest changes to avoid conflicts from parallel jobs
-          git pull --rebase
-          
           # Check if there are changes to commit (including new untracked files)
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit for ${{ matrix.bulletin }}"
           else
+            # Stage and stash changes before pulling to avoid conflicts
+            git add -A
+            git stash
+            
+            # Pull latest changes to avoid conflicts from parallel jobs
+            git pull --rebase
+            
+            # Restore stashed changes
+            git stash pop
+            
+            # Stage all changes again and commit
             git add -A
             git commit -m "Update ${{ matrix.bulletin }} bulletin [automated]
             


### PR DESCRIPTION
## Problem

The "Update Bulletins" GitHub Actions workflow was failing with:

```
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
Error: Process completed with exit code 128.
```

This happened because `git pull --rebase` was being called before the changes generated by the bulletin script were staged. Git cannot perform a rebase when there are unstaged changes in the working directory.

## Solution

Reorder the git operations to:
1. First check if there are any changes
2. Stage and stash the changes before pulling
3. Pull with rebase
4. Pop the stash to restore changes
5. Stage and commit

This ensures the working directory is clean when performing the rebase.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)