### PR TITLE
Fix UI tweaks: clickable cards and persistent unread indicators

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -539,8 +539,23 @@ header p {
     transition: color 0.2s ease;
 }
 
+/* Make the entire card clickable by stretching the link */
+.bulletin-card h2 a::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+}
+
 .bulletin-card h2 a:hover {
     color: var(--accent-color);
+}
+
+.bulletin-card {
+    cursor: pointer;
 }
 
 .bulletin-card .meta {
@@ -1026,6 +1041,8 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     
     // Set up IntersectionObserver to track when items are viewed
+    // Note: We mark items as viewed in localStorage but keep the visual indicator
+    // until the user navigates away from the page
     const observer = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
             if (entry.isIntersecting) {
@@ -1033,7 +1050,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const id = card.getAttribute('data-id');
                 if (id) {
                     markAsViewed(id);
-                    card.classList.remove('unread');
+                    // Don't remove 'unread' class - keep visual indicator until page navigation
                 }
             }
         });

--- a/tests/test_unread_tracking.py
+++ b/tests/test_unread_tracking.py
@@ -238,6 +238,33 @@ class TestUnreadJavaScript:
         assert "IntersectionObserver" in js
         assert "markAsViewed" in js
         assert "threshold" in js
+    
+    def test_bulletin_page_js_keeps_unread_indicator_until_navigation(self):
+        """Test that unread indicator stays visible until page navigation.
+        
+        The JS should mark items as viewed in localStorage but NOT remove
+        the 'unread' class immediately - it should stay until the user
+        navigates away from the page.
+        """
+        js = get_bulletin_page_js()
+        # Should NOT contain code that removes 'unread' class in the observer
+        assert "classList.remove('unread')" not in js
+        # Should still mark as viewed in localStorage
+        assert "markAsViewed(id)" in js
+
+
+class TestClickableCards:
+    """Tests for clickable card functionality."""
+    
+    def test_bulletin_card_has_stretched_link_css(self):
+        """Test that bulletin cards have CSS for stretched link (entire card clickable)."""
+        from generate_site import get_css
+        css = get_css()
+        # Check for the stretched link pattern using ::after pseudo-element
+        assert '.bulletin-card h2 a::after' in css
+        assert 'position: absolute' in css
+        # Check that the card has cursor pointer
+        assert 'cursor: pointer' in css
 
 
 class TestIntegration:


### PR DESCRIPTION
## Summary

This PR addresses the UI tweaks requested in issue #23.

## Changes

### 1. Make entire topic card clickable on main page
- Previously, only clicking the title text would navigate to the topic
- Now, clicking anywhere on the topic card will navigate to the topic
- Implemented using CSS stretched link pattern with `::after` pseudo-element
- Added `cursor: pointer` to the card for better UX feedback

### 2. Keep unread indicators visible until page navigation
- Previously, unread indicators (the "NEW" badge) would disappear immediately when an item was scrolled into view
- Now, the visual indicator stays visible for the entire page session
- Items are still marked as "viewed" in localStorage when scrolled into view (so they won't show as unread on the next visit)
- The unread indicator only disappears when the user navigates away from the page

## Testing

Added new tests to verify both fixes:
- `test_bulletin_card_has_stretched_link_css`: Verifies the CSS for clickable cards
- `test_bulletin_page_js_keeps_unread_indicator_until_navigation`: Verifies that the unread class is not removed immediately

All 22 tests pass.

Fixes #23

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e15a34a0335a40d39eb3792091245d68)