### PR TITLE
Add date handling instructions to agent prompt

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -34,6 +34,7 @@ Important guidelines:
 - Use fetch for getting full content from known URLs
 - Avoid duplicate rows--pick a canonical source, or list multiple sources in the same row
 - Do not include anything that's more than 1 month old, or more than 1 month away
+- Be careful about dates: always use the date from the source content (e.g., blog post publication date, event date) rather than the date you found or accessed the content. Do not confuse the current date with the content's actual date.
 
 Start by reading PROMPT.md, then check if BULLETIN.md exists, then search the web for 
 relevant information, and finally write the updated BULLETIN.md file.

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Tests for the PROMPT.md file content."""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestPromptContent:
+    """Tests for the PROMPT.md file content."""
+    
+    def test_prompt_file_exists(self):
+        """Test that PROMPT.md file exists."""
+        prompt_file = Path(__file__).parent.parent / "PROMPT.md"
+        assert prompt_file.exists(), "PROMPT.md file should exist"
+    
+    def test_prompt_contains_date_handling_instructions(self):
+        """Test that PROMPT.md contains instructions about careful date handling.
+        
+        The agent should be instructed to use dates from source content
+        (e.g., blog post publication dates) rather than the current date.
+        """
+        prompt_file = Path(__file__).parent.parent / "PROMPT.md"
+        content = prompt_file.read_text()
+        
+        # Check for date handling instructions
+        assert "careful about dates" in content.lower(), \
+            "PROMPT.md should contain instructions to be careful about dates"
+        assert "date from the source" in content.lower() or "date from the post" in content.lower(), \
+            "PROMPT.md should instruct to use dates from source content"
+    
+    def test_prompt_contains_today_date_placeholder(self):
+        """Test that PROMPT.md contains the today_date placeholder."""
+        prompt_file = Path(__file__).parent.parent / "PROMPT.md"
+        content = prompt_file.read_text()
+        
+        assert "{today_date}" in content, \
+            "PROMPT.md should contain {today_date} placeholder"
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

This PR adds instructions to the main prompt (`PROMPT.md`) to help the agent be more careful about dates when processing content.

## Changes

- **PROMPT.md**: Added a new guideline instructing the agent to:
  - Always use the date from the source content (e.g., blog post publication date, event date)
  - Not confuse the current date with the content's actual date
  - Not use the date the content was found or accessed

- **tests/test_prompt.py**: Added tests to verify:
  - The PROMPT.md file exists
  - The prompt contains date handling instructions
  - The prompt contains the `{today_date}` placeholder

## Testing

All 25 tests pass, including the 3 new tests added for prompt content verification.

Fixes #27

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/16be93c725244394aab9336b9cd7b432)